### PR TITLE
feat: wrap xdg-mime and xdg-settings in systemd-run

### DIFF
--- a/mkosi.extra/usr/bin/xdg-email
+++ b/mkosi.extra/usr/bin/xdg-email
@@ -1,2 +1,2 @@
 #!/bin/sh
-systemd-run --user --service-type=forking /usr/bin/xdg-email "${1}"
+systemd-run --user --service-type=forking /usr/bin/xdg-email "$@"

--- a/mkosi.extra/usr/bin/xdg-mime
+++ b/mkosi.extra/usr/bin/xdg-mime
@@ -1,0 +1,2 @@
+#!/bin/sh
+systemd-run --user --service-type=forking /usr/bin/xdg-mime "$@"

--- a/mkosi.extra/usr/bin/xdg-open
+++ b/mkosi.extra/usr/bin/xdg-open
@@ -1,2 +1,2 @@
 #!/bin/sh
-systemd-run --user --service-type=forking /usr/bin/xdg-open "${1}"
+systemd-run --user --service-type=forking /usr/bin/xdg-open "$@"

--- a/mkosi.extra/usr/bin/xdg-settings
+++ b/mkosi.extra/usr/bin/xdg-settings
@@ -1,0 +1,2 @@
+#!/bin/sh
+systemd-run --user --service-type=forking /usr/bin/xdg-settings "$@"


### PR DESCRIPTION
Wrap xdg-mime and xdg-settings in systemd-run. This is necessary because these tools sometimes need to interact with the user's X session. Using systemd-run with `--user` and `--service-type=forking` ensures that these tools are run in the user's session context, even when mkosi itself is running as root, resolving permission issues when these tools attempt to access user-specific X resources. The `--service- type=forking` is required because `xdg-mime` and `xdg-settings` typically fork, and systemd needs to track the forked processes correctly.

Influence:
1. Build an image with mkosi that relies on xdg-mime or xdg-settings.
2. Verify that mime type handling and settings changes work as expected within the image.
3. Check for any permission denied errors related to X resources when using applications or services within the built image.

feat: 使用 systemd-run 包装 xdg-mime 和 xdg-settings

使用 systemd-run 包装 xdg-mime 和 xdg-settings。 这是必要的，因为这些 工具有时需要与用户的 X 会话进行交互。 使用带有 `--user` 和 `--service-
type=forking` 的 systemd-run 确保这些工具在用户的会话上下文中运行，即使
mkosi 本身以 root 身份运行，也可以解决这些工具尝试访问用户特定的 X 资源
时出现的权限问题。 `--service-type=forking` 是必需的，因为 `xdg-mime` 和 `xdg-settings` 通常会 fork，并且 systemd 需要正确跟踪 fork 的进程。

Influence:
1. 使用 mkosi 构建一个依赖 xdg-mime 或 xdg-settings 的镜像。
2. 验证 MIME 类型处理和设置更改是否在镜像中按预期工作。
3. 检查在使用构建镜像中的应用程序或服务时，是否存在与 X 资源相关的任何权 限拒绝错误。