### PR TITLE
chore: update version number to 25.2.2.5

### DIFF
--- a/version.bash
+++ b/version.bash
@@ -1,2 +1,2 @@
 export APPID=org.deepin.base
-export VERSION="25.2.2.4"
+export VERSION="25.2.2.5"


### PR DESCRIPTION
Updated the VERSION environment variable from 25.2.2.4 to 25.2.2.5 in version.bash file. This change increments the version number as part of the standard development cycle to reflect new changes or bug fixes in the codebase.

Influence:
1. Verify that the new version number is correctly loaded in the application
2. Check that build systems properly recognize the updated version
3. Ensure packaging and deployment scripts use the correct version
4. Confirm version display in application UI (if applicable)