### PR TITLE
chore: update repository versions and bump app version

### DIFF
--- a/mkosi.apt.deepin/etc/apt/sources.list
+++ b/mkosi.apt.deepin/etc/apt/sources.list
@@ -1,1 +1,1 @@
-deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable crimson/2510 main community commercial
+deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable crimson/2520 main community commercial

--- a/version.bash
+++ b/version.bash
@@ -1,2 +1,2 @@
 export APPID=org.deepin.base
-export VERSION="25.2.2.6"
+export VERSION="25.2.3.0"


### PR DESCRIPTION
Updated apt sources for deepin and uniontech to point to new revision numbers (crimson/2520). Bumped application
version from 25.2.2.6 to 25.2.3.0 for the next release.

Influence:
1. Verify that apt update works with the new repository URLs
2. Confirm that packages can be installed from the updated repos
3. Check that the VERSION environment variable outputs 25.2.3.0
4. Test full build process with the updated sources